### PR TITLE
samples: bluetooth: peripheral_status: - remove thingy53 support

### DIFF
--- a/samples/bluetooth/peripheral_status/sample.yaml
+++ b/samples/bluetooth/peripheral_status/sample.yaml
@@ -23,7 +23,6 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
-      - thingy53/nrf5340/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -35,7 +34,6 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
-      - thingy53/nrf5340/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -50,8 +48,6 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
-      - thingy53/nrf5340/cpuapp
-      - thingy53/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -64,8 +60,6 @@ tests:
       - nrf52dk/nrf52810
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
-      - thingy53/nrf5340/cpuapp
-      - thingy53/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Temporarily remove Thingy53 support as it doesn't build after the USB stack change in Zephyr.
TODO: migrate to the new USB stack.