### PR TITLE
samples: bluetooth: Use unified mode in CS config logging

### DIFF
--- a/samples/bluetooth/channel_sounding_ras_initiator/src/main.c
+++ b/samples/bluetooth/channel_sounding_ras_initiator/src/main.c
@@ -415,10 +415,7 @@ static void config_create_cb(struct bt_conn *conn, uint8_t status,
 		const char *chsel_type_str[3] = {"Algorithm #3b", "Algorithm #3c", "Invalid"};
 		const char *ch3c_shape_str[3] = {"Hat shape", "X shape", "Invalid"};
 
-		uint8_t main_mode_idx = config->main_mode_type > 0 && config->main_mode_type < 4
-						? config->main_mode_type
-						: 4;
-		uint8_t sub_mode_idx = config->sub_mode_type < 4 ? config->sub_mode_type : 0;
+		uint8_t mode_idx = config->mode > 0 && config->mode < 4 ? config->mode : 4;
 		uint8_t role_idx = MIN(config->role, 2);
 		uint8_t rtt_type_idx = MIN(config->rtt_type, 7);
 		uint8_t phy_idx = config->cs_sync_phy > 0 && config->cs_sync_phy < 4
@@ -429,8 +426,7 @@ static void config_create_cb(struct bt_conn *conn, uint8_t status,
 
 		LOG_INF("CS config creation complete.\n"
 			" - id: %u\n"
-			" - main_mode_type: %s\n"
-			" - sub_mode_type: %s\n"
+			" - mode: %s\n"
 			" - min_main_mode_steps: %u\n"
 			" - max_main_mode_steps: %u\n"
 			" - main_mode_repetition: %u\n"
@@ -447,7 +443,7 @@ static void config_create_cb(struct bt_conn *conn, uint8_t status,
 			" - t_fcs_time_us: %u\n"
 			" - t_pm_time_us: %u\n"
 			" - channel_map: 0x%08X%08X%04X\n",
-			config->id, mode_str[main_mode_idx], mode_str[sub_mode_idx],
+			config->id, mode_str[mode_idx],
 			config->min_main_mode_steps, config->max_main_mode_steps,
 			config->main_mode_repetition, config->mode_0_steps, role_str[role_idx],
 			rtt_type_str[rtt_type_idx], phy_str[phy_idx],

--- a/samples/bluetooth/channel_sounding_ras_reflector/src/main.c
+++ b/samples/bluetooth/channel_sounding_ras_reflector/src/main.c
@@ -97,10 +97,7 @@ static void config_create_cb(struct bt_conn *conn, uint8_t status,
 		const char *chsel_type_str[3] = {"Algorithm #3b", "Algorithm #3c", "Invalid"};
 		const char *ch3c_shape_str[3] = {"Hat shape", "X shape", "Invalid"};
 
-		uint8_t main_mode_idx = config->main_mode_type > 0 && config->main_mode_type < 4
-						? config->main_mode_type
-						: 4;
-		uint8_t sub_mode_idx = config->sub_mode_type < 4 ? config->sub_mode_type : 0;
+		uint8_t mode_idx = config->mode > 0 && config->mode < 4 ? config->mode : 4;
 		uint8_t role_idx = MIN(config->role, 2);
 		uint8_t rtt_type_idx = MIN(config->rtt_type, 7);
 		uint8_t phy_idx = config->cs_sync_phy > 0 && config->cs_sync_phy < 4
@@ -111,8 +108,7 @@ static void config_create_cb(struct bt_conn *conn, uint8_t status,
 
 		LOG_INF("CS config creation complete.\n"
 			" - id: %u\n"
-			" - main_mode_type: %s\n"
-			" - sub_mode_type: %s\n"
+			" - mode: %s\n"
 			" - min_main_mode_steps: %u\n"
 			" - max_main_mode_steps: %u\n"
 			" - main_mode_repetition: %u\n"
@@ -129,7 +125,7 @@ static void config_create_cb(struct bt_conn *conn, uint8_t status,
 			" - t_fcs_time_us: %u\n"
 			" - t_pm_time_us: %u\n"
 			" - channel_map: 0x%08X%08X%04X\n",
-			config->id, mode_str[main_mode_idx], mode_str[sub_mode_idx],
+			config->id, mode_str[mode_idx],
 			config->min_main_mode_steps, config->max_main_mode_steps,
 			config->main_mode_repetition, config->mode_0_steps, role_str[role_idx],
 			rtt_type_str[rtt_type_idx], phy_str[phy_idx],


### PR DESCRIPTION
The separate main_mode_type and sub_mode_type fields in the CS configuration have been replaced by a single mode field.

Updates the logging in the config_create_cb callback to reflect this change. This aligns the sample with the updated API.

Signed-off-by: Aleksandr Mirlenko <aleksandr.mirlenko@nordicsemi.no>