### PR TITLE
samples: cellular: Fix a reference to the native_sim board

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/README.rst
+++ b/samples/cellular/nrf_cloud_multi_service/README.rst
@@ -1068,7 +1068,7 @@ These overlays show all the Kconfig settings changes needed to properly disable 
 Building with native simulator
 ==============================
 
-You can run this sample on the :zephyr:`native simlator <board:native_sim>` target.
+You can run this sample on the :zephyr:board:`native simulator <native_sim>` target.
 This enables you to try out connectivity without the need for embedded hardware.
 A Linux host or docker container is required to run the ``native_sim`` target.
 Some setup is needed to connect the application to the network.


### PR DESCRIPTION
Use the new :zephyr:board: directive correctly.